### PR TITLE
Enforce Gazelle build formatting as part of travis

### DIFF
--- a/.travis-bazelrc
+++ b/.travis-bazelrc
@@ -1,7 +1,14 @@
 # TODO: Set up remote caching.
 
+startup --host_jvm_args=-Xmx500m --host_jvm_args=-Xms500m
+
 # Disable sandboxing since it may fail inside of Travis' containers because the
 # mount system call is not permitted.
 build --spawn_strategy=standalone --genrule_strategy=standalone
 
+# Set some build options for travis container.
+build --local_resources=1536,1.5,0.5
 build --noshow_progress
+build --verbose_failures 
+build --sandbox_debug
+build --test_output=errors

--- a/.travis-bazelrc
+++ b/.travis-bazelrc
@@ -3,3 +3,5 @@
 # Disable sandboxing since it may fail inside of Travis' containers because the
 # mount system call is not permitted.
 build --spawn_strategy=standalone --genrule_strategy=standalone
+
+build --noshow_progress

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ matrix:
           go get github.com/alecthomas/gometalinter && gometalinter --install && gometalinter
     - os: linux
       env: V=0.15.0
-      go: 1.10.x
       before_install:
         - |
           if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
@@ -50,7 +49,6 @@ matrix:
             --bazelrc=.travis-bazelrc \
             test \
             --local_resources=1536,1.5,0.5 \
-            --noshow_progress \
             --verbose_failures \
             --test_output=errors \
             //...

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ matrix:
             --verbose_failures \
             --test_output=errors \
             //...
-
+        - ./check_gazelle.sh
+          
       notifications:
         email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,19 +40,22 @@ matrix:
           chmod +x install.sh
           ./install.sh --user
           rm -f install.sh
+      
+      install: true # Skip install go packages.
           
       script:
+        # Run all tests.
         - |
           bazel \
-            --batch \
-            --host_jvm_args=-Xmx500m --host_jvm_args=-Xms500m \
             --bazelrc=.travis-bazelrc \
             test \
-            --local_resources=1536,1.5,0.5 \
-            --verbose_failures \
-            --test_output=errors \
             //...
+        
+        # Check that BUILD files are formatted  correctly.
         - ./check_gazelle.sh
+
+        # Shutdown must be last.
+        - bazel shutdown 
           
       notifications:
         email: false

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@bazel_gazelle//:def.bzl", "gazelle")
 
+# gazelle:prefix github.com/prysmaticlabs/beacon-chain
 gazelle(
     name = "gazelle",
     prefix = "github.com/prysmaticlabs/beacon-chain",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,36 +1,43 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 http_archive(
     name = "io_bazel_rules_go",
     urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.12.1/rules_go-0.12.1.tar.gz"],
     sha256 = "8b68d0630d63d95dacc0016c3bb4b76154fe34fca93efd65d1c366de3fcb4294",
 )
+
 http_archive(
     name = "bazel_gazelle",
     urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.12.0/bazel-gazelle-0.12.0.tar.gz"],
     sha256 = "ddedc7aaeb61f2654d7d7d4fd7940052ea992ccdb031b8f9797ed143ac7e8d43",
 )
+
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+
 go_rules_dependencies()
+
 go_register_toolchains()
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+
 gazelle_dependencies()
 
-load("@bazel_gazelle//:deps.bzl", "go_repository")
 go_repository(
     name = "org_golang_x_crypto",
     importpath = "golang.org/x/crypto",
-    commit = "a49355c7e3f8fe157a85be2f77e6e269a0f89602"
+    commit = "a49355c7e3f8fe157a85be2f77e6e269a0f89602",
 )
+
 go_repository(
     name = "com_github_ethereum_go_ethereum",
     importpath = "github.com/ethereum/go-ethereum",
-    # Note: go-ethereum is not bazel-friendly with regards to cgo. We have a 
-    # a fork that has resolved these issues by disabling HID/USB support and 
-    # some manual fixes for c imports in the crypto package. This is forked 
-    # branch should be updated from time to time with the latest go-ethereum 
+    # Note: go-ethereum is not bazel-friendly with regards to cgo. We have a
+    # a fork that has resolved these issues by disabling HID/USB support and
+    # some manual fixes for c imports in the crypto package. This is forked
+    # branch should be updated from time to time with the latest go-ethereum
     # code.
     remote = "https://github.com/prysmaticlabs/bazel-go-ethereum",
     vcs = "git",
     # Last updated July 5, 2018
-    commit = "eb95493d32b6e1eb1cad63518637e1a958632389", 
+    commit = "eb95493d32b6e1eb1cad63518637e1a958632389",
 )

--- a/check_gazelle.sh
+++ b/check_gazelle.sh
@@ -3,7 +3,8 @@
 # Continous Integration script to check that BUILD.bazel files are as expected
 # when generated from gazelle.
 
-# Duplicate stdout with redirection to 5.
+# Duplicate redirect 5 to stdout so that it can be captured, but still printed
+# nicely.
 exec 5>&1
 
 # Run gazelle while piping a copy of the output to stdout via 5.

--- a/check_gazelle.sh
+++ b/check_gazelle.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Continous Integration script to check that BUILD.bazel files are as expected
+# when generated from gazelle.
+
+# Duplicate stdout with redirection to 5.
+exec 5>&1
+
+# Run gazelle while piping a copy of the output to stdout via 5.
+changes=$(bazel run //:gazelle -- fix --mode=diff | tee >(cat - >&5))
+
+# If the captured stdout is not empty then Gazelle has diffs.
+if [ -z "$changes" ]
+then
+  echo "OK: Gazelle does not need to be run"
+  exit 0
+else
+  echo "FAIL: Gazelle needs to be run"
+  echo "Please run bazel run //:gazelle -- fix"
+  exit 1
+fi


### PR DESCRIPTION
Added a gazelle script and ran fixed the formatting for the workspace file by running
```
bazel run //:gazelle -- fix
```
Which is slightly different (i.e. it also formats the WORKSPACE file if you include the `fix` argument). 
Not sure why and it's probably a bug that this doesn't happen already.

Also moved the bazel options into the bazel rc so that the gazelle build could enjoy the same options.